### PR TITLE
Fix remove unused icons

### DIFF
--- a/template
+++ b/template
@@ -29,9 +29,6 @@ do_install() {
         mv ${DESTDIR}/opt/brave.com/brave/product_logo_${size}.png         ${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps/brave-browser.png
     done
 
-    # Remove unused icons
-    rm ${DESTDIR}/opt/brave.com/brave/*.xpm
-
     # Remove the Debian/Ubuntu crontab
     rm -rf ${DESTDIR}/etc
     rm -rf ${DESTDIR}/opt/brave.com/brave/cron

--- a/template.template
+++ b/template.template
@@ -29,9 +29,6 @@ do_install() {
         mv ${DESTDIR}/opt/brave.com/brave/product_logo_${size}.png         ${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps/brave-browser.png
     done
 
-    # Remove unused icons
-    rm ${DESTDIR}/opt/brave.com/brave/*.xpm
-
     # Remove the Debian/Ubuntu crontab
     rm -rf ${DESTDIR}/etc
     rm -rf ${DESTDIR}/opt/brave.com/brave/cron


### PR DESCRIPTION
Fixes #4. 

`*.xpm` files (which were unused brave icons) no longer exist in the data folder which causes `rm` to fail. 